### PR TITLE
DB에서 경고,위험,제조사,모델,장력 데이터를 가져와 표시 구현 완료

### DIFF
--- a/dist-electron/preload.mjs
+++ b/dist-electron/preload.mjs
@@ -25,5 +25,16 @@ electron.contextBridge.exposeInMainWorld("electronAPI", {
 });
 electron.contextBridge.exposeInMainWorld("api", {
   // 이 함수를 호출하면 'get-tension-history' 채널로 Main 프로세스에 요청을 보냅니다.
-  getTensionHistory: () => electron.ipcRenderer.invoke("get-tension-history")
+  // getTensionHistory 함수는 TensionGraph 컴포넌트에서 사용됩니다.
+  getTensionHistory: () => electron.ipcRenderer.invoke("get-tension-history"),
+  // 
+  getAllMooringLines: () => electron.ipcRenderer.invoke("get-all-mooring-lines"),
+  getLatestTensions: () => electron.ipcRenderer.invoke("get-latest-tensions"),
+  // getTensionHistoryById 는 MooringLineInfo.tsx에서 사용됩니다.
+  getTensionHistoryById: (lineId) => electron.ipcRenderer.invoke("get-tension-history-by-id", lineId),
+  getDashBoardData: () => electron.ipcRenderer.invoke("get-dashboard-data"),
+  // 최종 정비, 총 사용시간을 가져옴
+  getLineInfo: (lineId) => electron.ipcRenderer.invoke("get-line-info", lineId),
+  // 경고/위험 알림 개수 가져옴
+  getAlertCount: () => electron.ipcRenderer.invoke("get-alert-count")
 });

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -31,3 +31,17 @@ interface Window {
     getMooringLineData: (lineId: number) => Promise<{ details: any; history: any; }>;
   };
 }
+
+interface Window {
+  api: {
+    getTensionHistory: () => Promise<any>;
+    getAllMooringLines: () => Promise<any[]>;
+    getLatestTensions: () => Promise<Array<{ lineId: number; time: string; tension: number }>>;
+    getTensionHistoryById: (lineId: string) => Promise<any[]>;
+    getDashBoardData: () => Promise<any[]>;
+
+    getLineInfo: (lineId: string) => Promise<{ lastInspected: string; usageHours: number; }>;
+    //getAlertCount: (lineId: string) => Promise<{ cautionCount: number; warningCount: number; }>;
+    getAlertCount: () => Promise<Array<{ lineId: number; cautionCount: number; warningCount: number; }>>;
+  };
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
     const [channel, ...omit] = args
     return ipcRenderer.invoke(channel, ...omit)
   },
+  
 
   // You can expose other APTs you need here.
   // ...
@@ -29,5 +30,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
 contextBridge.exposeInMainWorld('api', {
   // 이 함수를 호출하면 'get-tension-history' 채널로 Main 프로세스에 요청을 보냅니다.
-  getTensionHistory: () => ipcRenderer.invoke('get-tension-history')
+  // getTensionHistory 함수는 TensionGraph 컴포넌트에서 사용됩니다.
+  getTensionHistory: () => ipcRenderer.invoke('get-tension-history'),
+  // 
+  getAllMooringLines: () => ipcRenderer.invoke('get-all-mooring-lines'),
+  getLatestTensions: () => ipcRenderer.invoke('get-latest-tensions'),
+  // getTensionHistoryById 는 MooringLineInfo.tsx에서 사용됩니다.
+  getTensionHistoryById: (lineId: string) => ipcRenderer.invoke('get-tension-history-by-id', lineId),
+  getDashBoardData: () => ipcRenderer.invoke('get-dashboard-data'),
+  // 최종 정비, 총 사용시간을 가져옴
+  getLineInfo: (lineId: string) => ipcRenderer.invoke('get-line-info', lineId),
+  // 경고/위험 알림 개수 가져옴
+  getAlertCount: () => ipcRenderer.invoke('get-alert-count'),
+
+
 });
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "dotenv": "^17.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "recharts": "^3.2.1"
+        "recharts": "^3.2.1",
+        "serialport": "^13.0.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -1833,6 +1834,254 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@serialport/binding-mock": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-13.0.0.tgz",
+      "integrity": "sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "@serialport/parser-readline": "12.0.0",
+        "debug": "4.4.0",
+        "node-addon-api": "8.3.0",
+        "node-gyp-build": "4.8.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
+      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
+      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/parser-delimiter": "12.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/@serialport/bindings-interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
+      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@serialport/parser-byte-length": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
+      "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-cctalk": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-13.0.0.tgz",
+      "integrity": "sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-delimiter": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
+      "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-inter-byte-timeout": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-13.0.0.tgz",
+      "integrity": "sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-packet-length": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-13.0.0.tgz",
+      "integrity": "sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@serialport/parser-readline": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
+      "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/parser-delimiter": "13.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-ready": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-13.0.0.tgz",
+      "integrity": "sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-regex": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-13.0.0.tgz",
+      "integrity": "sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-slip-encoder": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-13.0.0.tgz",
+      "integrity": "sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-spacepacket": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-13.0.0.tgz",
+      "integrity": "sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
+      "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "4.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -3706,7 +3955,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6457,7 +6705,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6562,7 +6809,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -7547,6 +7793,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialport": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-13.0.0.tgz",
+      "integrity": "sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "13.0.0",
+        "@serialport/parser-byte-length": "13.0.0",
+        "@serialport/parser-cctalk": "13.0.0",
+        "@serialport/parser-delimiter": "13.0.0",
+        "@serialport/parser-inter-byte-timeout": "13.0.0",
+        "@serialport/parser-packet-length": "13.0.0",
+        "@serialport/parser-readline": "13.0.0",
+        "@serialport/parser-ready": "13.0.0",
+        "@serialport/parser-regex": "13.0.0",
+        "@serialport/parser-slip-encoder": "13.0.0",
+        "@serialport/parser-spacepacket": "13.0.0",
+        "@serialport/stream": "13.0.0",
+        "debug": "4.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/serialport/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/set-blocking": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^17.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "recharts": "^3.2.1"
+    "recharts": "^3.2.1",
+    "serialport": "^13.0.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import LoadingScreen from './components/LoadingScreen';
 import MainScreenRight from './components/MainScreenRight';
 import MainScreenLeft from './components/MainScreenLeft';
 import MainScreenSetting from './components/SettingScreen';
-import MooringLineInfo from './components/MooringLineInfo';
+//import MooringLineInfo from './components/MooringLineInfo';
 import TensionGraphScreen from './components/TensionGraph';
 
 // --- 타입 정의 임포트 ---

--- a/src/components/MainScreenLeft.tsx
+++ b/src/components/MainScreenLeft.tsx
@@ -19,8 +19,8 @@ interface MooringLineProps {
 }
 
 const getLineColorByTension = (tension: number): string => {
-  if (tension >= 12.0) return '#ff4d4d';
-  if (tension >= 10.0) return '#ffc107';
+  if (tension >= 120) return '#ff4d4d';
+  if (tension >= 100) return '#ffc107';
   if(tension === 0.0) return '#a6aaad'; // '#a6aaadff'에서 ff 제거
   return '#4caf50';
 };
@@ -115,36 +115,87 @@ export const MainScreenLeft = ({ onNavigate }: MainScreenLeftProps): JSX.Element
     setting: { x: 1000, y: 700, width: 20, height: 20 ,label : '설정'},
   };
   
-  // ✨ 상세 정보를 포함하는 확장된 목업 데이터 추가
-  const initialLines: MooringLineData[] = [
-    { id: 'Line 8', tension: 8.5,  material: 'Dyneema', diameter: 80, lastInspected: '2025-08-01', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 5, dangerCount: 1, usageHours: 1250, startX: shipX + bollardPositions.line_1.x, startY: shipY + bollardPositions.line_1.y, endX: pierCleatPositions.cleat1.x, endY: pierCleatPositions.cleat1.y },
-    { id: 'Line 7', tension: 9.2,  material: 'Polyester', diameter: 85, lastInspected: '2025-08-02', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 8, dangerCount: 2, usageHours: 1500, startX: shipX + bollardPositions.line_2.x, startY: shipY + bollardPositions.line_2.y, endX: pierCleatPositions.cleat2.x, endY: pierCleatPositions.cleat2.y },
-    { id: 'Line 6', tension: 8.8,  material: 'Polyester', diameter: 85, lastInspected: '2025-08-03', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 3, dangerCount: 0, usageHours: 900, startX: shipX + bollardPositions.line_3.x, startY: shipY + bollardPositions.line_3.y, endX: pierCleatPositions.cleat3.x, endY: pierCleatPositions.cleat3.y },
-    { id: 'Line 5', tension: 9.5,  material: 'Dyneema', diameter: 80, lastInspected: '2025-08-04', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 6, dangerCount: 1, usageHours: 1800, startX: shipX + bollardPositions.line_4.x, startY: shipY + bollardPositions.line_4.y, endX: pierCleatPositions.cleat4.x, endY: pierCleatPositions.cleat4.y },
-    { id: 'Line 4', tension: 12.1, material: 'Dyneema', diameter: 80, lastInspected: '2025-09-11', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 12, dangerCount: 4, usageHours: 2000, startX: shipX + bollardPositions.line_5.x, startY: shipY + bollardPositions.line_5.y, endX: pierCleatPositions.cleat5.x, endY: pierCleatPositions.cleat5.y },
-    { id: 'Line 3', tension: 11.5, material: 'Polyester', diameter: 85, lastInspected: '2025-09-12', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 9, dangerCount: 3, usageHours: 1700, startX: shipX + bollardPositions.line_6.x, startY: shipY + bollardPositions.line_6.y, endX: pierCleatPositions.cleat6.x, endY: pierCleatPositions.cleat6.y },
-    { id: 'Line 2', tension: 11.8, material: 'Polyester', diameter: 85, lastInspected: '2025-09-13', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 15, dangerCount: 5, usageHours: 2500, startX: shipX + bollardPositions.line_7.x, startY: shipY + bollardPositions.line_7.y, endX: pierCleatPositions.cleat7.x, endY: pierCleatPositions.cleat7.y },
-    { id: 'Line 1', tension: 12.5, material: 'Dyneema', diameter: 80, lastInspected: '2025-09-14', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 10, dangerCount: 3, usageHours: 2200, startX: shipX + bollardPositions.line_8.x, startY: shipY + bollardPositions.line_8.y, endX: pierCleatPositions.cleat8.x, endY: pierCleatPositions.cleat8.y },
-  ];
-    
-  const [lines, setLines] = useState<MooringLineData[]>(initialLines);
+  const [lines, setLines] = useState<MooringLineData[]>([]);
   const [selectedLine, setSelectedLine] = useState<MooringLineData | null>(null);
 
-  useEffect(() => {
-    const simulationInterval = setInterval(() => {
-      setLines(currentLines =>
-        currentLines.map(line => {
-          const lineNumber = parseInt(line.id.split(' ')[1]);
-          if (lineNumber<= 4) {
-            return { ...line, tension: 0 };
-          }
-          // 시뮬레이션 장력 값에 타입 명시 및 소수점 처리
-          return { ...line, tension: parseFloat((Math.random() * 6 + 7).toFixed(1)) };
-        })
-      );
-    }, 2000);
-    return () => clearInterval(simulationInterval);
-  }, []);
+  useEffect(() => {
+    const fetchLines = async () => {
+        try {
+            // 1. 세 종류의 데이터를 모두 한 번에 가져옵니다.
+            const [details, latest, alerts] = await Promise.all([
+                window.api.getAllMooringLines(),
+                window.api.getLatestTensions(),
+                window.api.getAlertCount(), // API 이름이 다를 경우 여기에 맞게 수정해주세요.
+            ]);
+
+            // 2. 'latest'와 'alerts' 데이터를 Map으로 변환하여 준비합니다.
+            const latestMap = new Map<number, { time: string; tension: number }>();
+            if (latest) {
+                for (const row of latest) latestMap.set(row.lineId, row);
+            }
+            const alertMap = new Map<number, { cautionCount: number; warningCount: number }>();
+            if (alerts) {
+                for (const row of alerts) alertMap.set(row.lineId, row);
+            }
+            
+            // 3. 화면에 표시할 순서대로 lineId 배열을 순회하며 객체를 조립합니다.
+            const displayOrder = [8, 7, 6, 5, 4, 3, 2, 1];
+            const mapped: MooringLineData[] = displayOrder.map((lineId, i) => {
+                const posIndex = i + 1;
+                const key = `line_${posIndex}` as keyof typeof bollardPositions;
+                const cleatKey = `cleat${posIndex}` as keyof typeof pierCleatPositions;
+                
+                const d = (details || []).find((x: any) => x.id === lineId) || {};
+                const lt = latestMap.get(lineId);
+                const ac = alertMap.get(lineId);
+
+                // 4. 모든 데이터를 조합하여 하나의 MooringLineData 객체를 생성합니다.
+                const assembledLine = {
+                    id: `Line ${lineId}`, 
+                    tension: lt ? Number(lt.tension) || 0 : 0,
+                    startX: shipX + (bollardPositions as any)[key].x,
+                    startY: shipY + (bollardPositions as any)[key].y,
+                    endX: (pierCleatPositions as any)[cleatKey].x,
+                    endY: (pierCleatPositions as any)[cleatKey].y,
+                    manufacturer: d.manufacturer ?? 'N/A',
+                    model: d.model ?? 'N/A',
+                    usageHours: d.usageTime ?? 0,
+                    lastInspected: d.maintenanceDate,
+                    cautionCount: ac?.cautionCount ?? 0,
+                    warningCount: ac?.warningCount ?? 0,
+                };
+
+                // ✅ [로그 1] 조립된 객체 하나하나를 콘솔에 출력하여 확인합니다.
+                console.log(`[map] lineId: ${lineId} 조립 완료`, assembledLine);
+
+                return assembledLine;
+            });
+
+            // ✅ [로그 2] 최종적으로 완성된 8개 객체의 전체 배열을 콘솔에 출력합니다.
+            console.log("--- 최종 조립된 전체 데이터 (mapped) ---", mapped);
+
+            // 5. 완성된 객체 배열을 state에 저장하여 화면을 업데이트합니다.
+            setLines(mapped);
+
+        } catch (e) {
+            console.error('계류줄 데이터 로드 실패:', e);
+        }
+    };
+
+    // 💡 1. 컴포넌트가 마운트되면 즉시 한 번 호출 (첫 로딩을 위해)
+    fetchLines(); 
+
+    // 💡 2. 5초(5000ms)마다 fetchLines 함수를 반복 호출하는 인터벌 설정
+    const intervalId = setInterval(fetchLines, 5000);
+
+    // 💡 3. 컴포넌트가 언마운트될 때 인터벌을 정리(clean-up)
+    return () => {
+        clearInterval(intervalId);
+    };
+}, []); // 의존성 배열은 비워두어 이 로직이 마운트 시 한 번만 실행되도록 합니다.
+
+  
+
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>

--- a/src/components/MainScreenRight.tsx
+++ b/src/components/MainScreenRight.tsx
@@ -25,8 +25,8 @@ interface MooringLineProps {
 }
 
 const getLineColorByTension = (tension: number): string => {
-  if (tension >= 12.0) return '#ff4d4d';
-  if (tension >= 10.0) return '#ffc107';
+  if (tension >= 120) return '#ff4d4d';
+  if (tension >= 100) return '#ffc107';
   if(tension === 0.0) return '#a6aaad'; // '#a6aaadff'에서 ff 제거
   return '#4caf50';
 };
@@ -122,37 +122,87 @@ export const MainScreenRight = ({ onNavigate }: MainScreenRightProps): JSX.Eleme
     setting: { x: 350, y: 700, width: 20, height: 20 ,label : '설정'},
   };
 
-  // ✨ 상세 정보를 포함하는 확장된 목업 데이터 추가 (오른쪽 뷰 전용 값)
-  const initialLines: MooringLineData[] = [
-    { id: 'Line 8', tension: 8.5,  material: 'Dyneema', diameter: 80, lastInspected: '2025-08-01', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 5, dangerCount: 1, usageHours: 1250, startX: shipX + bollardPositions.line_1.x, startY: shipY + bollardPositions.line_1.y, endX: pierCleatPositions.cleat1.x, endY: pierCleatPositions.cleat1.y },
-    { id: 'Line 7', tension: 9.2,  material: 'Polyester', diameter: 85, lastInspected: '2025-08-02', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 8, dangerCount: 2, usageHours: 1500, startX: shipX + bollardPositions.line_2.x, startY: shipY + bollardPositions.line_2.y, endX: pierCleatPositions.cleat2.x, endY: pierCleatPositions.cleat2.y },
-    { id: 'Line 6', tension: 8.8,  material: 'Polyester', diameter: 85, lastInspected: '2025-08-03', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 3, dangerCount: 0, usageHours: 900, startX: shipX + bollardPositions.line_3.x, startY: shipY + bollardPositions.line_3.y, endX: pierCleatPositions.cleat3.x, endY: pierCleatPositions.cleat3.y },
-    { id: 'Line 5', tension: 9.5,  material: 'Dyneema', diameter: 80, lastInspected: '2025-08-04', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 6, dangerCount: 1, usageHours: 1800, startX: shipX + bollardPositions.line_4.x, startY: shipY + bollardPositions.line_4.y, endX: pierCleatPositions.cleat4.x, endY: pierCleatPositions.cleat4.y },
-    { id: 'Line 4', tension: 12.1, material: 'Dyneema', diameter: 80, lastInspected: '2025-09-11', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 12, dangerCount: 4, usageHours: 2000, startX: shipX + bollardPositions.line_5.x, startY: shipY + bollardPositions.line_5.y, endX: pierCleatPositions.cleat5.x, endY: pierCleatPositions.cleat5.y },
-    { id: 'Line 3', tension: 11.5, material: 'Polyester', diameter: 85, lastInspected: '2025-09-12', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 9, dangerCount: 3, usageHours: 1700, startX: shipX + bollardPositions.line_6.x, startY: shipY + bollardPositions.line_6.y, endX: pierCleatPositions.cleat6.x, endY: pierCleatPositions.cleat6.y },
-    { id: 'Line 2', tension: 11.8, material: 'Polyester', diameter: 85, lastInspected: '2025-09-13', manufacturer: 'FiberPro', model: 'PolyStrong-B', warningCount: 15, dangerCount: 5, usageHours: 2500, startX: shipX + bollardPositions.line_7.x, startY: shipY + bollardPositions.line_7.y, endX: pierCleatPositions.cleat7.x, endY: pierCleatPositions.cleat7.y },
-    { id: 'Line 1', tension: 12.5, material: 'Dyneema', diameter: 80, lastInspected: '2025-09-14', manufacturer: 'RopeTech', model: 'DynaMax-A', warningCount: 10, dangerCount: 3, usageHours: 2200, startX: shipX + bollardPositions.line_8.x, startY: shipY + bollardPositions.line_8.y, endX: pierCleatPositions.cleat8.x, endY: pierCleatPositions.cleat8.y },
-  ];
-    
-  const [lines, setLines] = useState<MooringLineData[]>(initialLines);
+  const [lines, setLines] = useState<MooringLineData[]>([]);
 
   const [selectedLine, setSelectedLine] = useState<MooringLineData | null>(null);
 
-  useEffect(() => {
-    const simulationInterval = setInterval(() => {
-      setLines(currentLines =>
-        currentLines.map(line => {
-          const lineNumber = parseInt(line.id.split(' ')[1]);
-          if (lineNumber >= 5) {
-            return { ...line, tension: 0 };
-          }
-          // 시뮬레이션 장력 값에 타입 명시 및 소수점 처리
-          return { ...line, tension: parseFloat((Math.random() * 6 + 7).toFixed(1)) };
-        })
-      );
-    }, 2000);
-    return () => clearInterval(simulationInterval);
-  }, []);
+  useEffect(() => {
+    const fetchLines = async () => {
+        try {
+            // 1. 세 종류의 데이터를 모두 한 번에 가져옵니다.
+            const [details, latest, alerts] = await Promise.all([
+                window.api.getAllMooringLines(),
+                window.api.getLatestTensions(),
+                window.api.getAlertCount(), // API 이름이 다를 경우 여기에 맞게 수정해주세요.
+            ]);
+
+            // 2. 'latest'와 'alerts' 데이터를 Map으로 변환하여 준비합니다.
+            const latestMap = new Map<number, { time: string; tension: number }>();
+            if (latest) {
+                for (const row of latest) latestMap.set(row.lineId, row);
+            }
+            const alertMap = new Map<number, { cautionCount: number; warningCount: number }>();
+            if (alerts) {
+                for (const row of alerts) alertMap.set(row.lineId, row);
+            }
+            
+            // 3. 화면에 표시할 순서대로 lineId 배열을 순회하며 객체를 조립합니다.
+            const displayOrder = [8, 7, 6, 5, 4, 3, 2, 1];
+            const mapped: MooringLineData[] = displayOrder.map((lineId, i) => {
+                const posIndex = i + 1;
+                const key = `line_${posIndex}` as keyof typeof bollardPositions;
+                const cleatKey = `cleat${posIndex}` as keyof typeof pierCleatPositions;
+                
+                const d = (details || []).find((x: any) => x.id === lineId) || {};
+                const lt = latestMap.get(lineId);
+                const ac = alertMap.get(lineId);
+
+                // 4. 모든 데이터를 조합하여 하나의 MooringLineData 객체를 생성합니다.
+                const assembledLine = {
+                    id: `Line ${lineId}`, 
+                    tension: lt ? Number(lt.tension) || 0 : 0,
+                    startX: shipX + (bollardPositions as any)[key].x,
+                    startY: shipY + (bollardPositions as any)[key].y,
+                    endX: (pierCleatPositions as any)[cleatKey].x,
+                    endY: (pierCleatPositions as any)[cleatKey].y,
+                    manufacturer: d.manufacturer ?? 'N/A',
+                    model: d.model ?? 'N/A',
+                    usageHours: d.usageTime ?? 0,
+                    lastInspected: d.maintenanceDate,
+                    cautionCount: ac?.cautionCount ?? 0,
+                    warningCount: ac?.warningCount ?? 0,
+                };
+
+                // ✅ [로그 1] 조립된 객체 하나하나를 콘솔에 출력하여 확인합니다.
+                console.log(`[map] lineId: ${lineId} 조립 완료`, assembledLine);
+
+                return assembledLine;
+            });
+
+            // ✅ [로그 2] 최종적으로 완성된 8개 객체의 전체 배열을 콘솔에 출력합니다.
+            console.log("--- 최종 조립된 전체 데이터 (mapped) ---", mapped);
+
+            // 5. 완성된 객체 배열을 state에 저장하여 화면을 업데이트합니다.
+            setLines(mapped);
+
+        } catch (e) {
+            console.error('계류줄 데이터 로드 실패:', e);
+        }
+    };
+
+    // 💡 1. 컴포넌트가 마운트되면 즉시 한 번 호출 (첫 로딩을 위해)
+    fetchLines(); 
+
+    // 💡 2. 5초(5000ms)마다 fetchLines 함수를 반복 호출하는 인터벌 설정
+    const intervalId = setInterval(fetchLines, 5000);
+
+    // 💡 3. 컴포넌트가 언마운트될 때 인터벌을 정리(clean-up)
+    return () => {
+        clearInterval(intervalId);
+    };
+}, []); // 의존성 배열은 비워두어 이 로직이 마운트 시 한 번만 실행되도록 합니다.
+  
+
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>

--- a/src/components/TensionGraph.tsx
+++ b/src/components/TensionGraph.tsx
@@ -8,13 +8,13 @@ interface HistoryData {
 }
 
 // TypeScript가 window.api 객체를 인식하도록 타입을 선언합니다.
-declare global {
+/*declare global {
   interface Window {
     api: {
       getTensionHistory: () => Promise<HistoryData[]>;
     }
   }
-}
+}*/
 
 interface TensionGraphScreenProps {
   onGoBack: () => void;


### PR DESCRIPTION
1.DB에서 제조사, 모델명, 최근 장력 데이터, 경고횟수, 위험횟수, 최종정비, 총 사용시간 데이터를 가져와 계류줄 상태 창에 표시 구현 완료

2.MainScreenLeft/Right/tsx에서
window.api.getAllMooringLines(),
window.api.getLatestTensions(),
window.api.getAlertCount() 를 사용해 제조사, 모델명, 경고횟수, 위험횟수, 최종정비, 총 사용시간을 불러온다.

3.최근의 장력 데이터의 경우 MooringInfo.tsx의 window.api.getTensionHistoryById(lineId);에서 불러온다
Main 화면의 계류줄 line을 클릭하면, lineId ex(Line 4)같은 변수에서 숫자만 파싱되어 쿼리문에 들어가 각 계류줄 번호에 해당하는 장력 데이터만 불러온다